### PR TITLE
Ensure val_set.csv is loaded relative to script location

### DIFF
--- a/.github/workflows/test-submission-checker.yml
+++ b/.github/workflows/test-submission-checker.yml
@@ -16,7 +16,6 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/automotive/2d-object-detection/accuracy_cognata.py
+++ b/automotive/2d-object-detection/accuracy_cognata.py
@@ -69,7 +69,7 @@ def main():
     else:
         _, label_map, label_info = prepare_cognata(
             args.cognata_root_path, folders, cameras)
-    files = read_dataset_csv("val_set.csv")
+    files = read_dataset_csv(os.path.join(os.path.dirname(os.path.abspath(__file__)),"val_set.csv"))
     files = [{'img': os.path.join(args.cognata_root_path, f['img']), 'ann': os.path.join(
         args.dataset_path, f['ann'])} for f in files]
     val_set = Cognata(args.dataset_path, len(files))

--- a/automotive/2d-object-detection/accuracy_cognata.py
+++ b/automotive/2d-object-detection/accuracy_cognata.py
@@ -69,7 +69,11 @@ def main():
     else:
         _, label_map, label_info = prepare_cognata(
             args.cognata_root_path, folders, cameras)
-    files = read_dataset_csv(os.path.join(os.path.dirname(os.path.abspath(__file__)),"val_set.csv"))
+    files = read_dataset_csv(
+        os.path.join(
+            os.path.dirname(
+                os.path.abspath(__file__)),
+            "val_set.csv"))
     files = [{'img': os.path.join(args.cognata_root_path, f['img']), 'ann': os.path.join(
         args.dataset_path, f['ann'])} for f in files]
     val_set = Cognata(args.dataset_path, len(files))

--- a/automotive/semantic-segmentation/accuracy_cognata.py
+++ b/automotive/semantic-segmentation/accuracy_cognata.py
@@ -52,7 +52,11 @@ def main():
     num_classes = 19
     metrics = StreamSegMetrics(num_classes)
     metrics.reset()
-    files = read_dataset_csv("val_set.csv")
+    files = read_dataset_csv(
+        os.path.join(
+            os.path.dirname(
+                os.path.abspath(__file__)),
+            "val_set.csv"))
     image_size = args.image_size
     val_loader = Cognata(args.dataset_path, length=len(files))
     with open(args.mlperf_accuracy_file, "r") as f:


### PR DESCRIPTION
Resolved an issue where running the script from outside its directory caused a FileNotFoundError.

Now constructs the path to val_set.csv using the script's absolute path.
