### PR TITLE
Adas patch

### DIFF
--- a/SubmissionExample.ipynb
+++ b/SubmissionExample.ipynb
@@ -325,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +344,7 @@
     "        \"status\": \"available\",\n",
     "        \"submitter\": \"mlperf-org\",\n",
     "        \"system_name\": \"tf-gpu\",\n",
-    "        \"system_type\": \"datacenter\",\n",
+    "        \"system_type\": \"adas\",\n",
     "        \n",
     "        \"number_of_nodes\": 1,\n",
     "        \"host_memory_capacity\": \"32GB\",\n",

--- a/Submission_Guidelines.md
+++ b/Submission_Guidelines.md
@@ -5,12 +5,12 @@ The MLPerf inference submission rules are spread between the [MLCommons policies
 
 ## Hardware requirements
 1. MLCommons inference results can be submitted on any hardware and we have past results from Raspberry Pi to high-end inference servers.
-2. Closed category submission for datacenter category needs **ECC RAM** and also needs to have the **networking** capabilities as detailed [here](https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc#networking-from-the-v30-round)
+2. Closed category submission for adas category needs **ECC RAM** and also needs to have the **networking** capabilities as detailed [here](https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc#networking-from-the-v30-round)
 3. Power submissions need an [approved power analyzer](https://github.com/mlcommons/inference_policies/blob/master/power_measurement.adoc#74-which-power-analyzers-aka-meters-are-supported).
 
 ## Things to Know
  
-1. Closed submission needs performance and accuracy run for all the required scenarios (as per edge/datacenter category) with accuracy within 99% or 99.9% as given in the respective task READMEs. Further, the model weights are not supposed to be altered except for quantization. If any of these constraints are not met, the submission cannot go under closed division but can still be submitted under open division.
+1. Closed submission needs performance and accuracy run for all the required scenarios (as per adas category) with accuracy within 99% or 99.9% as given in the respective task READMEs. Further, the model weights are not supposed to be altered except for quantization. If any of these constraints are not met, the submission cannot go under closed division but can still be submitted under open division.
 2. Reference models are mostly fp32 and reference implementations are just for reference and not meant to be directly used by submitters as they are not optimized for performance.
 3. Calibration document due **one week** before the submission deadline
 4. Power submission needs a power analyzer (approved by SPEC Power) and EULA signature to get access to SPEC PTDaemon
@@ -21,31 +21,21 @@ The MLPerf inference submission rules are spread between the [MLCommons policies
 MLPerf inference submissions are expected to be run on various hardware and supported software stacks. Therefore, MLCommons provides only reference implementations to guide submitters in creating optimal implementations for their specific software and hardware configurations. Additionally, all implementations used for MLPerf inference submissions are available in the MLCommons [Inference results](https://github.com/orgs/mlcommons/repositories?q=inference_results_v+sort%3Aname) repositories (under `closed/<submitter>/code` directory), offering further guidance for submitters developing their own implementations.
 
 ### Expected time to do benchmark runs
-1. Closed submission under datacenter needs offline and server scenario runs with a minimum of ten minutes needed for both. 
-2. Closed submission under the edge category needs single stream, multi-stream (only for R50 and retinanet), and offline scenarios. A minimum of ten minutes is needed for each scenario. 
-3. Further two (three for ResNet50) compliance runs are needed for closed division, each taking at least 10 minutes for each scenario.
-4. SingleStream, MultiStream and Server scenarios use early stopping and so can always finish around 10 minutes
-5. Offline scenario needs a minimum of 24756 input queries to be processed -- can take hours for low-performing models like 3dunet, LLMs, etc.
-6. Open division has no accuracy constraints, no required compliance runs, and can be submitted for any single scenario. There is no constraint on the model used except that the model accuracy must be validated on the accuracy dataset used in the corresponding MLPerf inference task [or must be preapproved](https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc#412-relaxed-constraints-for-the-open-division).
-7. Power submission needs an extra ranging mode to determine the peak current usage and this often doubles the overall experiment run time. If this overhead is too much, ranging run can be reduced to 5 minutes run using mechanisms like [this](https://github.com/mlcommons/cm4mlops/blob/main/script/benchmark-program-mlperf/customize.py#L18).
+1. Closed submission under adas needs a single stream or constant stream scenario with a minimum of 6636 samples. 
+2. Further two compliance runs are needed for closed division taking similar time as the normal performance run.
+3. Open division has no accuracy constraints, no required compliance runs, and can be submitted for any single scenario. There is no constraint on the model used except that the model accuracy must be validated on the accuracy dataset used in the corresponding MLPerf inference task [or must be preapproved](https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc#412-relaxed-constraints-for-the-open-division).
 
 
 ## Validity of the submission
 
-1. [MLCommons Inference submission checker](https://github.com/mlcommons/inference/blob/master/tools/submission/submission_checker.py) is provided to ensure that all submissions are passing the required checks.
-2. In the unlikely event that there is an error on the submission checker for your submission, please raise a GitHub issue [here](https://github.com/mlcommons/inference/issues)
+1. [MLCommons automotive submission checker](https://github.com/mlcommons/mlperf_automotive/blob/master/tools/submission/submission_checker.py) is provided to ensure that all submissions are passing the required checks.
+2. In the unlikely event that there is an error on the submission checker for your submission, please raise a GitHub issue [here](https://github.com/mlcommons/mlperf_automotive/issues)
 3. Any submission passing the submission checker is valid to go to the review discussions but submitters are still required to answer any queries and fix any issues being reported by other submitters.
 
 ### Reviewing other submissions
 1. Ensure that the `system_desc_id.json` file is having meaningful responses - `submission_checker` only checks for the existence of the fields.
-2. For power submissions, `power settings` and `analyzer table` files are to be submitted, and even though the submission checker checks for the existence of these files, the content of [these files](https://github.com/mlcommons/inference_policies/blob/master/power_measurement.adoc#64-power-management-settings) must be checked manually for validity.
-3. README files in the submission directory must be checked to make sure that the instructions are reproducible.
-4. For closed datacenter submissions, [ECC RAM and Networking requirements](https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc#constraints-for-the-closed-division) must be ensured.
-5. Submission checker might be reporting warnings and some of these warnings can warrant an answer from the submitter.
+2. README files in the submission directory must be checked to make sure that the instructions are reproducible.
+3. Submission checker might be reporting warnings and some of these warnings can warrant an answer from the submitter.
 
-## Changes from MLCommons Inference 4.0
-
-1. One new benchmark in the datacenter category: Mixtral-8x7B. No changes in the edge category.
-2. For power submissions, there is no code change. 
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ The currently valid [MLPerf Automotive Benchmarks](index_gh.md) as of MLPerf inf
 - **Latency Target**: 99.9%
 - **Accuracy Constraint**: 99.9%
 - **Framework Support**: ONNX, PyTorch
-- **Submission Category**: Edge
+- **Submission Category**: ADAS
 
 ## Camera-Based 3D Object Detection
 ### [BEVFormer (tiny)](benchmarks/camera-3d-detection/bevformer.md)
@@ -29,7 +29,7 @@ The currently valid [MLPerf Automotive Benchmarks](index_gh.md) as of MLPerf inf
 - **Latency Target**: 99.9%
 - **Accuracy Constraint**: 99%
 - **Framework Support**: ONNX, PyTorch
-- **Submission Category**: Edge
+- **Submission Category**: ADAS
 
 ## Semantic Segmentation
 ### [DeepLabv3+](benchmarks/semantic-segmentation/deeplabv3plus.md)
@@ -43,12 +43,12 @@ The currently valid [MLPerf Automotive Benchmarks](index_gh.md) as of MLPerf inf
 - **Latency Target**: 99.9%
 - **Accuracy Constraint**: 99.9%
 - **Framework Support**: ONNX (8MP & Dynamic), PyTorch
-- **Submission Category**: Edge
+- **Submission Category**: ADAS
 
 ---
 
 ## Submission Categories
-- **Edge Category**: All benchmarks are applicable to the edge category for the automotive inference v0.5
+- **ADAS Category**: All benchmarks are applicable to the ADAS category for the automotive inference v0.5
 
 ## High Accuracy Variants
 - **Benchmarks**: All the benchmarks for submission round v0.5 have high accuracy variant.

--- a/tools/submission/generate_final_report.py
+++ b/tools/submission/generate_final_report.py
@@ -149,10 +149,7 @@ def main():
     ]
 
     filter_scenarios = {
-        "datacenter": {
-            # not present in v0.5
-        },
-        "edge": {
+        "adas": {
             "ssd": ["SingleStream", "ConstantStream"],
             "bevformer": ["SingleStream", "ConstantStream"],
             "deeplabv3plus": ["SingleStream", "ConstantStream"],
@@ -241,7 +238,7 @@ def main():
         f.write(json.dumps(id_dict, indent=4))
 
     for category in ["closed", "open", "network"]:
-        for suite in ["datacenter", "edge"]:
+        for suite in ["adas"]:
             MakeWorksheet(
                 df,
                 indices[category],

--- a/tools/submission/submission_checker.py
+++ b/tools/submission/submission_checker.py
@@ -87,9 +87,18 @@ MODEL_CONFIG = {
             "ssd": {"ConstantStream": 10000000}
         },
         "min-queries": {
-            "bevformer": {"ConstantStream": 6636},
-            "deeplabv3plus": {"ConstantStream": 6636},
-            "ssd": {"ConstantStream": 6636}
+            "bevformer": {
+                "ConstantStream": 6636
+                "SingleStream": 6636,
+            },
+            "deeplabv3plus": {
+                "ConstantStream": 6636
+                "SingleStream": 6636,
+            },
+            "ssd": {
+                "ConstantStream": 6636
+                "SingleStream": 6636,
+            }
         },
     },
 }

--- a/tools/submission/submission_checker.py
+++ b/tools/submission/submission_checker.py
@@ -31,24 +31,16 @@ MODEL_CONFIG = {
             "deeplabv3plus",
             "ssd",
         ],
-        "required-scenarios-datacenter": {
-            "bevformer": ["ConstantStream", "SingleStream"],
-            "deeplabv3plus": ["ConstantStream", "SingleStream"],
-            "ssd": ["ConstantStream", "SingleStream"]
+        "required-scenarios-adas": {
+            "bevformer": ["SingleStream"],
+            "deeplabv3plus": ["SingleStream"],
+            "ssd": ["SingleStream"]
         },
-        "optional-scenarios-datacenter": {},
-        "required-scenarios-edge": {
-            "bevformer": ["ConstantStream", "SingleStream"],
-            "deeplabv3plus": ["ConstantStream", "SingleStream"],
-            "ssd": ["ConstantStream", "SingleStream"]
+        "optional-scenarios-adas": {
+            "bevformer": ["ConstantStream"],
+            "deeplabv3plus": ["ConstantStream"],
+            "ssd": ["ConstantStream"]
         },
-        "optional-scenarios-edge": {},
-        "required-scenarios-datacenter-edge": {
-            "bevformer": ["ConstantStream", "SingleStream"],
-            "deeplabv3plus": ["ConstantStream", "SingleStream"],
-            "ssd": ["ConstantStream", "SingleStream"]
-        },
-        "optional-scenarios-datacenter-edge": {},
         "accuracy-target": {
             "bevformer": ("mAP_3D", .2683556 * 0.99),
             "deeplabv3plus": ("mIOU", .924355 * 0.999),
@@ -88,15 +80,15 @@ MODEL_CONFIG = {
         },
         "min-queries": {
             "bevformer": {
-                "ConstantStream": 6636
+                "ConstantStream": 6636,
                 "SingleStream": 6636,
             },
             "deeplabv3plus": {
-                "ConstantStream": 6636
+                "ConstantStream": 6636,
                 "SingleStream": 6636,
             },
             "ssd": {
-                "ConstantStream": 6636
+                "ConstantStream": 6636,
                 "SingleStream": 6636,
             }
         },
@@ -317,17 +309,9 @@ class Config:
         self.skip_power_check = skip_power_check
 
     def set_type(self, submission_type):
-        if submission_type == "datacenter":
-            self.required = self.base["required-scenarios-datacenter"]
-            self.optional = self.base["optional-scenarios-datacenter"]
-        elif submission_type == "edge":
-            self.required = self.base["required-scenarios-edge"]
-            self.optional = self.base["optional-scenarios-edge"]
-        elif (
-            submission_type == "datacenter,edge" or submission_type == "edge,datacenter"
-        ):
-            self.required = self.base["required-scenarios-datacenter-edge"]
-            self.optional = self.base["optional-scenarios-datacenter-edge"]
+        if submission_type == "adas":
+            self.required = self.base["required-scenarios-adas"]
+            self.optional = self.base["optional-scenarios-adas"]
         else:
             raise ValueError("invalid system type")
 
@@ -1556,8 +1540,7 @@ def check_results_dir(
                         results[name] = None
                         continue
                     system_type = system_json.get("system_type")
-                    valid_system_types = [
-                        "datacenter", "edge", "datacenter,edge", "edge,datacenter"]
+                    valid_system_types = ["adas"]
 
                     if system_type not in valid_system_types:
                         log.error(


### PR DESCRIPTION
Closes #55 and closes #56.

Adds min queries for single stream to the submission checker.

Removes datacenter and edge categories and replaces with adas.