### PR TITLE
Fix #67: handling target latency in ConstantStream

### DIFF
--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -90,8 +90,8 @@ TestSettingsInternal::TestSettingsInternal(
 #endif
         });
       }
-      target_latency =
-          std::chrono::nanoseconds(requested.server_target_latency_ns);
+      uint64_t tgt_lat_ns = 1000000000 / target_qps;
+      target_latency = std::chrono::nanoseconds(tgt_lat_ns);
       target_latency_percentile = requested.server_target_latency_percentile;
       max_async_queries = requested.server_max_async_queries;
       break;
@@ -765,8 +765,6 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
   // keys that apply to ConstantStream
   lookupkv(model, "ConstantStream", "target_latency_percentile", nullptr,
            &server_target_latency_percentile, 0.01);
-  lookupkv(model, "ConstantStream", "target_latency", &server_target_latency_ns,
-           nullptr, 1000 * 1000);
 
   // keys that can be overriden in user.conf (the provided values still need to
   // pass the submission checker rules)


### PR DESCRIPTION
Trying to fix issue: https://github.com/mlcommons/mlperf_automotive/issues/67
