### PR TITLE
V0.5 patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ See the individual Readme files in the reference app for details.
 
 | model | reference app | framework | dataset |
 | ---- | ---- | ---- | ---- |
-| ssd-resnet50| [v0.5/2D object detection](https://github.com/mlcommons/mlperf_automotive/tree/v0.5abtf/automotive/2d-object-detection) | pytorch, onnx | Cognata |
-| bevformer-tiny | [v0.5/camera-based 3D object detection](https://github.com/mlcommons/mlperf_automotive/tree/v0.5abtf/automotive/camera-3d-detection) |pytorch, onnx | NuScenes |
-| DeepLabV3+ | [v0.5/semantic segmentation](https://github.com/mlcommons/mlperf_automotive/tree/v0.5abtf/automotive/semantic-segmentation) |pytorch, onnx | Cognata |
+| ssd-resnet50| [v0.5/2D object detection](https://github.com/mlcommons/mlperf_automotive/tree/master/automotive/2d-object-detection) | pytorch, onnx | Cognata |
+| bevformer-tiny | [v0.5/camera-based 3D object detection](https://github.com/mlcommons/mlperf_automotive/tree/master/automotive/camera-3d-detection) | onnx | NuScenes |
+| DeepLabV3+ | [v0.5/semantic segmentation](https://github.com/mlcommons/mlperf_automotive/tree/master/automotive/semantic-segmentation) |pytorch, onnx | Cognata |

--- a/Submission_Guidelines.md
+++ b/Submission_Guidelines.md
@@ -21,7 +21,7 @@ The MLPerf inference submission rules are spread between the [MLCommons policies
 MLPerf inference submissions are expected to be run on various hardware and supported software stacks. Therefore, MLCommons provides only reference implementations to guide submitters in creating optimal implementations for their specific software and hardware configurations. Additionally, all implementations used for MLPerf inference submissions are available in the MLCommons [Inference results](https://github.com/orgs/mlcommons/repositories?q=inference_results_v+sort%3Aname) repositories (under `closed/<submitter>/code` directory), offering further guidance for submitters developing their own implementations.
 
 ### Expected time to do benchmark runs
-1. Closed submission under adas needs a single stream or constant stream scenario with a minimum of 6636 samples. 
+1. Closed submission under adas needs a single stream or constant stream scenario with a minimum of 6636 or 100000 samples, respectively. 
 2. Further two compliance runs are needed for closed division taking similar time as the normal performance run.
 3. Open division has no accuracy constraints, no required compliance runs, and can be submitted for any single scenario. There is no constraint on the model used except that the model accuracy must be validated on the accuracy dataset used in the corresponding MLPerf inference task [or must be preapproved](https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc#412-relaxed-constraints-for-the-open-division).
 

--- a/automotive/camera-3d-detection/main.py
+++ b/automotive/camera-3d-detection/main.py
@@ -135,7 +135,7 @@ def get_args():
     parser.add_argument("--count", type=int, help="dataset items to use")
     parser.add_argument("--debug", action="store_true", help="debug")
     parser.add_argument(
-        "--performance-sample-count", type=int, help="performance sample count", default=512
+        "--performance-sample-count", type=int, help="performance sample count", default=256
     )
     parser.add_argument(
         "--max-latency", type=float, help="mlperf max latency in pct tile"

--- a/loadgen/mlperf.conf
+++ b/loadgen/mlperf.conf
@@ -8,7 +8,7 @@ bevformer.*.use_grouped_qsl = 1
 
 # Set performance_sample_count for each model.
 # User can optionally set this to higher values in user.conf.
-bevformer.*.performance_sample_count_override = 512
+bevformer.*.performance_sample_count_override = 256
 deeplabv3plus.*.performance_sample_count_override = 128
 ssd.*.performance_sample_count_override = 128
 

--- a/loadgen/mlperf.conf
+++ b/loadgen/mlperf.conf
@@ -23,6 +23,7 @@ ssd.*.performance_sample_count_override = 128
 *.SingleStream.min_duration = 600000
 *.SingleStream.min_query_count = 6636
 
+*.ConstantStream.min_query_count = 100000
 *.ConstantStream.target_latency = 10
 *.ConstantStream.target_latency_percentile = 99.9
 *.ConstantStream.target_duration = 0

--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -75,7 +75,7 @@ TestSettingsInternal::TestSettingsInternal(
       target_latency_percentile =
           requested.multi_stream_target_latency_percentile;
       break;
-    case TestScenario::ConstantStream:
+    case TestScenario::ConstantStream:{
       if (requested.server_target_qps >= 0.0) {
         target_qps = requested.server_target_qps;
       } else {
@@ -97,6 +97,7 @@ TestSettingsInternal::TestSettingsInternal(
       target_latency_percentile = requested.server_target_latency_percentile;
       max_async_queries = requested.server_max_async_queries;
       break;
+    }
     case TestScenario::Offline:
       // target_latency_percentile is not used in Offline, but set it to
       // 0.99 anyway to avoid garbage value.

--- a/tools/submission/submission_checker.py
+++ b/tools/submission/submission_checker.py
@@ -53,7 +53,7 @@ MODEL_CONFIG = {
 
         },
         "performance-sample-count": {
-            "bevformer": 512,
+            "bevformer": 256,
             "deeplabv3plus": 128,
             "ssd": 128
         },

--- a/tools/submission/submission_checker.py
+++ b/tools/submission/submission_checker.py
@@ -73,11 +73,7 @@ MODEL_CONFIG = {
             "schedule_rng_seed": 9933818062894767841,
         },
         "ignore_errors": [],
-        "latency-constraint": {
-            "bevformer": {"ConstantStream": 10000000},
-            "deeplabv3plus": {"ConstantStream": 10000000},
-            "ssd": {"ConstantStream": 10000000}
-        },
+        "latency-constraint": {},
         "min-queries": {
             "bevformer": {
                 "ConstantStream": 100000,

--- a/tools/submission/submission_checker.py
+++ b/tools/submission/submission_checker.py
@@ -80,15 +80,15 @@ MODEL_CONFIG = {
         },
         "min-queries": {
             "bevformer": {
-                "ConstantStream": 6636,
+                "ConstantStream": 100000,
                 "SingleStream": 6636,
             },
             "deeplabv3plus": {
-                "ConstantStream": 6636,
+                "ConstantStream": 100000,
                 "SingleStream": 6636,
             },
             "ssd": {
-                "ConstantStream": 6636,
+                "ConstantStream": 100000,
                 "SingleStream": 6636,
             }
         },


### PR DESCRIPTION
Addresses outstanding issues.

-Reduces BEVFormer performance sample count to 256
-Increases the minimum query requirements for Constant Stream to 100000
-Removes ConstantStream latency constraints in the submission checker.

Additionally

-Updates READMEs
-Fixes bug introduced in loadgen