### PR TITLE
Add Hardened Category submission package + checker

### DIFF
--- a/tools/submission/hardened/INTEGRATION.md
+++ b/tools/submission/hardened/INTEGRATION.md
@@ -1,0 +1,97 @@
+# Wiring the Hardened checker into `submission_checker.py`
+
+This package adds the **Hardened Category** disclosure check on top of the existing
+MLPerf Automotive submission checker. It is intentionally additive: no existing
+behaviour changes, and the new check only fires when a system declares
+`"status": "hardened"`.
+
+## Why this slots in cleanly
+
+The base checker already has everything the hook needs:
+
+| Fact in `submission_checker.py` (commit `5d11f17`) | Consequence |
+|---|---|
+| `VALID_AVAILABILITIES` already contains `"hardened"` (line ~185) | The category *is* the system's `status`; no new enum needed. |
+| `status` is read at line ~1808 as `available = system_json.get("status").lower()` | That is the exact point to branch on `hardened`. |
+| `system_id_json = division/submitter/systems/<system_desc>.json` (line ~1795) | The hardened package lives right beside it as `<system_desc>_hardened.json`. |
+| Checker is pure stdlib, returns booleans, logs `error`/`warning` | `hardened_checker` follows the same contract — no new dependency. |
+| Benchmark models live in `MODEL_CONFIG[version]["models"]` | `hardened_checker` imports them rather than duplicating; falls back if run standalone. |
+
+## The patch
+
+**1. Import at the top of `submission_checker.py`:**
+
+```python
+from hardened_checker import check_hardened_package
+```
+
+**2. In `check_results_dir`, right after the `status` validation block
+(immediately after the `if available not in VALID_AVAILABILITIES:` check,
+~line 1814), add:**
+
+```python
+                    # Hardened category requires an additional disclosure package.
+                    if available == "hardened":
+                        hardened_json = os.path.join(
+                            division, submitter, "systems",
+                            system_desc + "_hardened.json"
+                        )
+                        if not check_hardened_package(
+                            name, hardened_json, system_desc_id=system_desc
+                        ):
+                            results[name] = None
+                            continue
+```
+
+That is the entire integration. `name`, `division`, `submitter`, `system_desc`,
+and `results` are all already in scope at that point in the loop.
+
+## Submission directory layout
+
+```
+<division>/<submitter>/
+├── systems/
+│   ├── drive_orin_adas.json            # existing system description (status: "hardened")
+│   └── drive_orin_adas_hardened.json   # NEW: hardened package (this schema)
+├── results/<system_desc>/<model>/<scenario>/...
+├── measurements/...
+└── code/...
+```
+
+The `system_desc_id` field inside the hardened package must equal the system
+description's basename (`drive_orin_adas`); the checker enforces this so a package
+can't be silently attached to the wrong results line.
+
+## Standalone use (no integration required)
+
+```bash
+# validate one package
+python3 hardened_checker.py <division>/<submitter>/systems/<sys>_hardened.json \
+    --system-desc-id <sys>
+
+# run the test suite
+python3 -m unittest test_hardened_checker -v
+```
+
+Exit code is `0` when valid, `1` otherwise — suitable for CI on the results repo.
+
+## Error vs. warning policy
+
+- **error** → the submission is rejected (missing required section/field, ADAS/AD
+  without safety manual or tool qualification, quantizer with no calibration
+  description, application/harness with no run command, target-dependent autotuning
+  with no autotuning config, an audit identifier that pins nothing, malformed
+  hash/checksum, an undisclosed local patch).
+- **warning** → a reviewer should look, but it's valid (no component marked
+  production-intended, runtime BOM missing firmware/OS/engine, no AEC-Q100 listed,
+  a compilation recipe naming a non-benchmark model — left as a warning so Open
+  division can use custom model names).
+
+## Optional: JSON-Schema gate
+
+`schema/hardened_package.schema.json` is the normative structural spec. The runtime
+checker does **not** require `jsonschema` (matching the base checker), but the test
+suite will additionally validate the examples against the schema if `jsonschema` is
+installed. If MLCommons later wants a hard schema gate in CI, add `jsonschema` to the
+tooling requirements and validate before calling `validate_hardened_package`.
+```

--- a/tools/submission/hardened/README.md
+++ b/tools/submission/hardened/README.md
@@ -1,0 +1,67 @@
+# MLPerf Automotive — Hardened Category submission package
+
+Reference implementation of the **Hardened System** disclosure package and its
+validator, turning the *Hardened Category Straw Man* into an executable spec that
+plugs into the existing `tools/submission/submission_checker.py`.
+
+A "Hardened" submission (`status: "hardened"` — already a valid availability in the
+base checker) is a production-intended system. On top of the ordinary MLCommons
+artifacts it must ship one extra file, `systems/<system_desc>_hardened.json`, that
+discloses the production software path, a build-time/runtime software bill of
+materials, OSS/proprietary/licensing provenance, a reproducible model-compilation
+recipe, and profile-appropriate safety/security evidence.
+
+Sensitive material is **not** placed in the file. Each component records an immutable
+identifier (commit / build ID / checksum); the artifact itself is made available to a
+neutral third-party auditor under the standard MLCommons audit + NDA process.
+
+## Contents
+
+| Path | What it is |
+|---|---|
+| `schema/hardened_package.schema.json` | Normative JSON Schema (draft-07) — the formal form of the straw man's "Solution space" fields. |
+| `hardened_checker.py` | Pure-stdlib validator + CLI. Mirrors `submission_checker.py`'s error/warning idiom and enforces the cross-field rules a static schema can't. |
+| `examples/drive_orin_adas_hardened.json` | Full, realistic ADAS package (BEVFormer + SSD, INT8, TensorRT-style autotuning). Doubles as the worked template. |
+| `examples/ivi_qm_hardened.json` | Minimal IVI/QM package (Llama-3.1-8B voice assistant) — shows safety manual is *not* required for IVI. |
+| `examples/invalid_adas_hardened.json` | Deliberately broken package used by tests to prove the checker catches real violations. |
+| `test_hardened_checker.py` | 19 unit tests: valid examples, every cross-field rule, optional schema conformance. |
+| `INTEGRATION.md` | Exact ~10-line patch to wire the check into `submission_checker.py`, plus directory layout. |
+
+## Quick start
+
+```bash
+# validate a package (exit 0 = valid, 1 = invalid)
+python3 hardened_checker.py examples/drive_orin_adas_hardened.json --system-desc-id drive_orin_adas
+
+# run the tests
+python3 -m unittest test_hardened_checker -v
+```
+
+## How the package maps to the straw man
+
+| Straw man section | Schema property | Notable enforced rule |
+|---|---|---|
+| Production-intended software inventory | `production_intended_inventory[]` | each entry needs a pinning `identifier`; ≥1 should be production-intended (warning otherwise) |
+| SBOM — build-time | `software_bill_of_materials.build_toolchain_bom[]` | `quantizer`/`calibration_tool` roles must describe the calibration set |
+| SBOM — runtime | `software_bill_of_materials.runtime_execution_bom[]` | `application`/`benchmark_harness` must give the run command + LoadGen connection |
+| OSS components | `oss_components[]` | a declared local patch must be referenced **or** described at feature level |
+| Supplier/vendor components | `proprietary_components[]` | owner, build ID, interface role, unique checksum, external-availability flag all required |
+| Licensing | `license_summary[]` | license family + binary/source redistribution booleans |
+| Reproducibility | `reproducibility` | public repo refs (valid commit hash) + per-model recipe; **target-dependent autotuning requires `autotuning_config`** |
+| Safety evidence | `safety_evidence` | **profile-driven:** IVI→security manual; ADAS/AD→security + safety manual + tool qualification |
+
+## Design choices worth flagging to the WG
+
+- **The category is the `status` field.** `"hardened"` already exists in the base
+  checker's `VALID_AVAILABILITIES`, so no parallel taxonomy is introduced — the
+  package simply attaches to a hardened system description.
+- **Profiles (IVI / ADAS / AD) live in the package, not in `system_type`.** The base
+  checker currently locks `system_type` to `"adas"`, so the three Hardened System
+  Profiles from inference_rules 6.1 are carried in `hardened_profile` and drive which
+  safety evidence is mandatory.
+- **No new runtime dependency.** The validator is stdlib-only like the base checker;
+  `jsonschema` is used only by the (skippable) schema-conformance test.
+- **Errors reject; warnings inform.** This keeps the gate strict on
+  reproducibility/provenance/safety while leaving room for Open-division and
+  early-maturity submissions (e.g. a recipe naming a custom model is a warning).
+```

--- a/tools/submission/hardened/examples/drive_orin_adas_hardened.json
+++ b/tools/submission/hardened/examples/drive_orin_adas_hardened.json
@@ -1,0 +1,246 @@
+{
+  "hardened_package_version": "v1.0",
+  "system_desc_id": "drive_orin_adas",
+  "hardened_profile": "ADAS",
+  "anticipated_safety_goal": "ASIL-B at system level for the perception stack; QM for the benchmark harness and host tooling.",
+
+  "production_intended_inventory": [
+    {
+      "component_name": "SoC firmware (BSP)",
+      "functional_role": "Boot firmware and platform security controller for the target ECU",
+      "supplier_or_owner": "Acme Silicon",
+      "used_during_benchmark": true,
+      "intended_for_production": true,
+      "provenance": "proprietary",
+      "identifier": { "build_id": "BSP-6.0.9.2-prod", "binary_checksum": "sha256:9f1c2d3e4a5b60718293a4b5c6d7e8f90112233445566778899aabbccddeeff0" }
+    },
+    {
+      "component_name": "ML compiler (graph -> engine)",
+      "functional_role": "Compiles ONNX graphs into target engine plans with INT8 quantization",
+      "supplier_or_owner": "Acme Silicon",
+      "used_during_benchmark": true,
+      "intended_for_production": true,
+      "provenance": "proprietary",
+      "identifier": { "build_id": "axc-10.4.0", "internal_source_identifier": "acme://toolchain/axc/10.4.0" }
+    },
+    {
+      "component_name": "Safety inference runtime",
+      "functional_role": "Loads and executes compiled engines on the accelerator with the production scheduler",
+      "supplier_or_owner": "Acme Silicon",
+      "used_during_benchmark": true,
+      "intended_for_production": true,
+      "provenance": "proprietary",
+      "identifier": { "build_id": "safe-rt-3.2.1", "binary_checksum": "sha256:0011223344556677889900aabbccddeeff00112233445566778899aabbccddee" }
+    },
+    {
+      "component_name": "MLPerf LoadGen harness",
+      "functional_role": "Benchmark-only query driver linking LoadGen to the SUT",
+      "supplier_or_owner": "MLCommons",
+      "used_during_benchmark": true,
+      "intended_for_production": false,
+      "provenance": "open-source",
+      "identifier": { "repository_url": "https://github.com/mlcommons/mlperf_automotive", "commit_hash": "5d11f17c5316683369837e0cff3da64c5e094745" }
+    }
+  ],
+
+  "software_bill_of_materials": {
+    "build_toolchain_bom": [
+      {
+        "component_name": "PyTorch",
+        "role": "training_framework",
+        "version": "2.4.0",
+        "configuration_flags": "export only; no retraining (closed division)",
+        "identifier": { "release_tag": "v2.4.0" }
+      },
+      {
+        "component_name": "ONNX exporter",
+        "role": "export_tooling",
+        "version": "1.16.1",
+        "configuration_flags": "opset=17, dynamic_axes disabled",
+        "identifier": { "release_tag": "v1.16.1" }
+      },
+      {
+        "component_name": "Acme ML compiler (axc)",
+        "role": "ml_compiler",
+        "version": "10.4.0",
+        "configuration_flags": "--int8 --best --workspace=4096 --calib=entropy",
+        "identifier": { "build_id": "axc-10.4.0" }
+      },
+      {
+        "component_name": "Acme PTQ calibrator",
+        "role": "quantizer",
+        "version": "10.4.0",
+        "configuration_flags": "entropy calibration, per-tensor scales",
+        "calibration_dataset_description": "500-image MLCommons-provided Cognata/NuScenes calibration subset; no other data used.",
+        "identifier": { "build_id": "axc-10.4.0" }
+      },
+      {
+        "component_name": "Engine plan packager",
+        "role": "packaging_tool",
+        "version": "1.1.0",
+        "configuration_flags": "bundles engine + scaler metadata into signed .plan",
+        "identifier": { "build_id": "pkg-1.1.0" }
+      }
+    ],
+    "runtime_execution_bom": [
+      {
+        "component_name": "SoC firmware (BSP)",
+        "component_type": "firmware",
+        "version": "6.0.9.2",
+        "configuration": "production security profile, secure boot enabled",
+        "delivery_method": "BSP image",
+        "identifier": { "build_id": "BSP-6.0.9.2-prod" }
+      },
+      {
+        "component_name": "Accelerator kernel driver",
+        "component_type": "kernel_driver",
+        "version": "6.0.9",
+        "configuration": "MIG disabled, persistence mode on",
+        "identifier": { "build_id": "kmd-6.0.9" }
+      },
+      {
+        "component_name": "Hardened Linux (PREEMPT_RT)",
+        "component_type": "operating_system",
+        "version": "kernel 5.15.118-rt",
+        "configuration": "CIS-aligned hardening profile, read-only rootfs"
+      },
+      {
+        "component_name": "Safety inference runtime",
+        "component_type": "safety_runtime",
+        "version": "3.2.1",
+        "configuration": "device=0, scheduling=static, batch=1 (SingleStream)"
+      },
+      {
+        "component_name": "Perception application",
+        "component_type": "application",
+        "version": "2.7.0",
+        "configuration": "single-camera-set BEVFormer pipeline",
+        "run_command": "perception_app --engine bevformer.plan --loadgen-mode SingleStream --qsl 256 --backend safe-rt"
+      },
+      {
+        "component_name": "MLPerf LoadGen harness",
+        "component_type": "benchmark_harness",
+        "version": "v1.0",
+        "configuration": "links to perception_app over shared-memory queue",
+        "run_command": "run_and_time.sh --scenario SingleStream --model bevformer; LoadGen runs on host CPU, SUT callback in perception_app"
+      }
+    ]
+  },
+
+  "oss_components": [
+    {
+      "component_name": "MLPerf LoadGen",
+      "upstream_url": "https://github.com/mlcommons/mlperf_automotive",
+      "immutable_identifier": "5d11f17c5316683369837e0cff3da64c5e094745",
+      "role": "Query generation and latency measurement (benchmark-only)",
+      "has_local_patches": false
+    },
+    {
+      "component_name": "ONNX Runtime",
+      "upstream_url": "https://github.com/microsoft/onnxruntime",
+      "immutable_identifier": "v1.18.0",
+      "role": "Reference parity check during export validation",
+      "has_local_patches": true,
+      "patch_feature_description": "Backported a layernorm fusion fix; affects only export-time numerical parity checks, not the deployed engine.",
+      "affects_kernel_or_tactic_selection": false
+    }
+  ],
+
+  "proprietary_components": [
+    {
+      "component_name": "Acme ML compiler (axc)",
+      "owner": "Acme Silicon",
+      "version_or_build_id": "axc-10.4.0",
+      "interface_role": "compiler backend producing engine plans",
+      "internal_identifier_or_checksum": "sha256:1122334455667788990011223344556677889900aabbccddeeff001122334455",
+      "available_to_external_customers": true,
+      "distribution_model": "production license under SDK agreement",
+      "affects_compiled_artifact": true
+    },
+    {
+      "component_name": "Safety inference runtime",
+      "owner": "Acme Silicon",
+      "version_or_build_id": "safe-rt-3.2.1",
+      "interface_role": "safety runtime / inference engine",
+      "internal_identifier_or_checksum": "sha256:0011223344556677889900aabbccddeeff00112233445566778899aabbccddee",
+      "available_to_external_customers": true,
+      "distribution_model": "production license",
+      "affects_compiled_artifact": true
+    }
+  ],
+
+  "license_summary": [
+    {
+      "component_name": "MLPerf LoadGen",
+      "license_family": "Apache-2.0",
+      "binary_redistribution_allowed": true,
+      "source_redistribution_allowed": true,
+      "additional_terms": null
+    },
+    {
+      "component_name": "Acme ML compiler (axc)",
+      "license_family": "proprietary-commercial",
+      "binary_redistribution_allowed": false,
+      "source_redistribution_allowed": false,
+      "additional_terms": "NDA; safety manual required"
+    },
+    {
+      "component_name": "Safety inference runtime",
+      "license_family": "proprietary-commercial",
+      "binary_redistribution_allowed": false,
+      "source_redistribution_allowed": false,
+      "additional_terms": "field-of-use restriction (automotive only)"
+    }
+  ],
+
+  "reproducibility": {
+    "mlperf_automotive_repo_reference": {
+      "implementation_repo_url": "https://github.com/mlcommons/mlperf_automotive",
+      "results_repo_url": "https://github.com/mlcommons/mlperf_automotive_results_v1.0",
+      "commit_hash": "5d11f17c5316683369837e0cff3da64c5e094745"
+    },
+    "model_compilation_recipe": [
+      {
+        "model": "bevformer",
+        "steps": [
+          "python export/bevformer_to_onnx.py --weights bevformer_tiny.pth --out bevformer.onnx",
+          "axc --onnx bevformer.onnx --int8 --best --calib=entropy --calib-data calib/ --out bevformer.plan",
+          "pkg --engine bevformer.plan --sign --out bevformer.signed.plan"
+        ],
+        "compiler_config": "axc 10.4.0; --int8 --best --workspace=4096 --calib=entropy",
+        "quantization_description": "Post-training INT8, per-tensor entropy calibration on the 500-image MLCommons calibration subset; symmetric scales; method description fits in <1KB and is fully reproducible from the calibration data + fp16 weights.",
+        "graph_optimizations": "conv+bn fold, layernorm fusion, attention fusion",
+        "autotuning_config": "tactic sources = CUBLAS,CUDNN,EDGE_MASK_CONVOLUTIONS; timing iterations=8; deterministic builder cache pinned via --timing-cache=bevformer.cache",
+        "target_dependent_autotuning": true
+      },
+      {
+        "model": "ssd",
+        "steps": [
+          "python export/ssd_to_onnx.py --weights ssd_resnet.pth --out ssd.onnx",
+          "axc --onnx ssd.onnx --int8 --best --calib=entropy --calib-data calib_ssd/ --out ssd.plan"
+        ],
+        "compiler_config": "axc 10.4.0; --int8 --best --calib=entropy",
+        "quantization_description": "Post-training INT8, per-tensor entropy calibration on the 128-image SSD calibration subset.",
+        "graph_optimizations": "conv+bn fold, NMS plugin",
+        "autotuning_config": "tactic sources = CUBLAS,CUDNN; timing iterations=8; --timing-cache=ssd.cache",
+        "target_dependent_autotuning": true
+      }
+    ]
+  },
+
+  "safety_evidence": {
+    "security_manual_reference": { "name": "Acme SoC Security Manual", "version": "6.0", "availability": "under NDA" },
+    "safety_manual_reference": { "name": "Acme NPU IP Safety Manual (QM IP, ASIL-B system assumptions)", "version": "3.2", "availability": "under NDA" },
+    "tool_qualification_reference": { "name": "axc Tool Qualification Report (ISO 26262 TCL3)", "version": "10.4", "availability": "under NDA" },
+    "hardware_qualification": ["AEC-Q100 Grade 2", "High safety integrity compute"],
+    "certification_evidence": [
+      {
+        "standard": "ISO 26262",
+        "status": "in_progress",
+        "asil_target": "ASIL-B",
+        "assessor": "TUV (engagement ongoing)",
+        "reference": { "name": "Functional Safety Assessment Plan", "version": "0.9", "availability": "on request" }
+      }
+    ]
+  }
+}

--- a/tools/submission/hardened/examples/invalid_adas_hardened.json
+++ b/tools/submission/hardened/examples/invalid_adas_hardened.json
@@ -1,0 +1,60 @@
+{
+  "_comment": "Deliberately invalid ADAS package used by the test suite. Expected errors: missing safety_manual + tool_qualification (ADAS profile), quantizer without calibration description, application without run_command, target_dependent_autotuning without autotuning_config, bad commit hash, has_local_patches with no disclosure.",
+  "hardened_package_version": "v1.0",
+  "system_desc_id": "broken_adas",
+  "hardened_profile": "ADAS",
+
+  "production_intended_inventory": [
+    {
+      "component_name": "Runtime",
+      "functional_role": "executes engine",
+      "supplier_or_owner": "Acme",
+      "used_during_benchmark": true,
+      "intended_for_production": false,
+      "provenance": "proprietary",
+      "identifier": {}
+    }
+  ],
+
+  "software_bill_of_materials": {
+    "build_toolchain_bom": [
+      { "component_name": "axc", "role": "quantizer", "version": "10.4.0" }
+    ],
+    "runtime_execution_bom": [
+      { "component_name": "App", "component_type": "application", "version": "1.0" }
+    ]
+  },
+
+  "oss_components": [
+    {
+      "component_name": "ORT",
+      "upstream_url": "https://github.com/microsoft/onnxruntime",
+      "immutable_identifier": "v1.18.0",
+      "role": "parity",
+      "has_local_patches": true
+    }
+  ],
+
+  "proprietary_components": [],
+  "license_summary": [],
+
+  "reproducibility": {
+    "mlperf_automotive_repo_reference": {
+      "implementation_repo_url": "https://github.com/mlcommons/mlperf_automotive",
+      "results_repo_url": "https://github.com/mlcommons/mlperf_automotive_results_v1.0",
+      "commit_hash": "not-a-hash"
+    },
+    "model_compilation_recipe": [
+      {
+        "model": "bevformer",
+        "steps": ["axc --onnx bevformer.onnx --out bevformer.plan"],
+        "compiler_config": "axc 10.4.0",
+        "target_dependent_autotuning": true
+      }
+    ]
+  },
+
+  "safety_evidence": {
+    "security_manual_reference": { "name": "Acme Security Manual", "version": "6.0" }
+  }
+}

--- a/tools/submission/hardened/examples/ivi_qm_hardened.json
+++ b/tools/submission/hardened/examples/ivi_qm_hardened.json
@@ -1,0 +1,111 @@
+{
+  "hardened_package_version": "v1.0",
+  "system_desc_id": "ivi_cockpit_qm",
+  "hardened_profile": "IVI",
+  "anticipated_safety_goal": "QM (no safety goal); in-vehicle infotainment voice assistant.",
+
+  "production_intended_inventory": [
+    {
+      "component_name": "Cockpit SoC firmware",
+      "functional_role": "Boot firmware for the IVI domain controller",
+      "supplier_or_owner": "Acme Silicon",
+      "used_during_benchmark": true,
+      "intended_for_production": true,
+      "provenance": "proprietary",
+      "identifier": { "build_id": "ivi-bsp-4.1.0" }
+    },
+    {
+      "component_name": "LLM inference engine",
+      "functional_role": "Executes the quantized Llama-3.1-8B engine for the voice assistant",
+      "supplier_or_owner": "Acme Silicon",
+      "used_during_benchmark": true,
+      "intended_for_production": true,
+      "provenance": "proprietary",
+      "identifier": { "build_id": "llm-rt-2.0.0" }
+    }
+  ],
+
+  "software_bill_of_materials": {
+    "build_toolchain_bom": [
+      { "component_name": "PyTorch", "role": "training_framework", "version": "2.4.0" },
+      { "component_name": "ONNX exporter", "role": "export_tooling", "version": "1.16.1" },
+      {
+        "component_name": "Acme LLM compiler",
+        "role": "ml_compiler",
+        "version": "10.4.0",
+        "configuration_flags": "--w4a16 --kv-cache=paged"
+      },
+      {
+        "component_name": "AWQ quantizer",
+        "role": "quantizer",
+        "version": "0.2.0",
+        "calibration_dataset_description": "MMLU-derived calibration subset provided by MLCommons; 256 prompts."
+      }
+    ],
+    "runtime_execution_bom": [
+      { "component_name": "Cockpit SoC firmware", "component_type": "firmware", "version": "4.1.0", "delivery_method": "BSP image" },
+      { "component_name": "Accelerator driver", "component_type": "kernel_driver", "version": "6.0.9" },
+      { "component_name": "Automotive Linux", "component_type": "operating_system", "version": "kernel 6.1-aglnext" },
+      { "component_name": "LLM inference engine", "component_type": "inference_engine", "version": "2.0.0", "configuration": "paged KV-cache, batch=1" },
+      {
+        "component_name": "Voice assistant app + harness",
+        "component_type": "benchmark_harness",
+        "version": "v1.0",
+        "run_command": "run_and_time.sh --scenario SingleStream --model llama3_1-8b; LoadGen on host CPU"
+      }
+    ]
+  },
+
+  "oss_components": [
+    {
+      "component_name": "MLPerf LoadGen",
+      "upstream_url": "https://github.com/mlcommons/mlperf_automotive",
+      "immutable_identifier": "5d11f17c5316683369837e0cff3da64c5e094745",
+      "role": "Query generation and latency measurement"
+    }
+  ],
+
+  "proprietary_components": [
+    {
+      "component_name": "Acme LLM compiler",
+      "owner": "Acme Silicon",
+      "version_or_build_id": "10.4.0",
+      "interface_role": "compiler backend",
+      "internal_identifier_or_checksum": "sha256:abc1230000000000000000000000000000000000000000000000000000000000",
+      "available_to_external_customers": true,
+      "distribution_model": "production license"
+    }
+  ],
+
+  "license_summary": [
+    { "component_name": "MLPerf LoadGen", "license_family": "Apache-2.0", "binary_redistribution_allowed": true, "source_redistribution_allowed": true, "additional_terms": null },
+    { "component_name": "Acme LLM compiler", "license_family": "proprietary-commercial", "binary_redistribution_allowed": false, "source_redistribution_allowed": false, "additional_terms": "NDA" }
+  ],
+
+  "reproducibility": {
+    "mlperf_automotive_repo_reference": {
+      "implementation_repo_url": "https://github.com/mlcommons/mlperf_automotive",
+      "results_repo_url": "https://github.com/mlcommons/mlperf_automotive_results_v1.0",
+      "commit_hash": "5d11f17c5316683369837e0cff3da64c5e094745"
+    },
+    "model_compilation_recipe": [
+      {
+        "model": "llama3_1-8b",
+        "steps": [
+          "python export/llama_to_onnx.py --weights llama3.1-8b --out llama.onnx",
+          "axc-llm --onnx llama.onnx --w4a16 --kv-cache=paged --out llama.plan"
+        ],
+        "compiler_config": "axc-llm 10.4.0; --w4a16 --kv-cache=paged",
+        "quantization_description": "W4A16 AWQ on 256-prompt MMLU calibration subset; greedy decode preserved per reference.",
+        "graph_optimizations": "rotary fusion, paged attention",
+        "target_dependent_autotuning": false
+      }
+    ]
+  },
+
+  "safety_evidence": {
+    "security_manual_reference": { "name": "Acme Cockpit Security Manual", "version": "4.1", "availability": "under NDA" },
+    "hardware_qualification": ["AEC-Q100 Grade 3"],
+    "certification_evidence": []
+  }
+}

--- a/tools/submission/hardened/schema/hardened_package.schema.json
+++ b/tools/submission/hardened/schema/hardened_package.schema.json
@@ -1,0 +1,430 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://mlcommons.org/automotive/schemas/hardened_package.schema.json",
+  "title": "MLPerf Automotive Hardened Category Package",
+  "description": "Normative schema for the additional disclosure package required by the MLPerf Automotive 'Hardened System' submission category. This package is supplied IN ADDITION to all ordinary MLCommons submission artifacts. It lives alongside the per-system description as 'systems/<system_desc>_hardened.json' and is validated by tools/submission/hardened_checker.py. Sensitive or proprietary material is NOT expected to be placed in this file; instead an immutable identifier (commit hash / build ID / checksum) is recorded and the artifact is made available to a neutral third-party auditor under the standard MLCommons audit/NDA process.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "hardened_package_version",
+    "system_desc_id",
+    "hardened_profile",
+    "production_intended_inventory",
+    "software_bill_of_materials",
+    "oss_components",
+    "proprietary_components",
+    "license_summary",
+    "reproducibility"
+  ],
+  "properties": {
+    "hardened_package_version": {
+      "description": "Version of THIS hardened-package schema/format the file conforms to. Lets the checker select validation rules the same way MODEL_CONFIG keys on the benchmark version.",
+      "type": "string",
+      "enum": ["v0.5", "v1.0"]
+    },
+    "system_desc_id": {
+      "description": "Must equal the basename of the corresponding systems/<system_desc>.json (without extension). Binds this package to exactly one results line.",
+      "type": "string",
+      "minLength": 1
+    },
+    "hardened_profile": {
+      "description": "Which Hardened System Profile this submission targets. Drives which evidence is mandatory (see inference_rules.adoc 6.1). IVI is typically QM; ADAS is QM..ASIL-B; AD is ASIL-B and above.",
+      "type": "string",
+      "enum": ["IVI", "ADAS", "AD"]
+    },
+    "anticipated_safety_goal": {
+      "description": "Free-text statement of the anticipated ML-stack production safety goal (e.g. 'QM', 'ASIL-B at system level'). MLPerf does NOT certify safety; this records the submitter's stated intent only.",
+      "type": "string"
+    },
+
+    "production_intended_inventory": {
+      "description": "List of software components used while running the benchmark, each explicitly marked for whether it is intended for production. Separates benchmark-only utilities from the production path (firmware, drivers, model compiler, runtime libraries, graph executors, safety wrappers, orchestration).",
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/inventory_component" }
+    },
+
+    "software_bill_of_materials": {
+      "description": "Component-level BOM decomposed into the build-time toolchain (what produces the deployable artifact) and the runtime execution stack (what loads and executes it on the target).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["build_toolchain_bom", "runtime_execution_bom"],
+      "properties": {
+        "build_toolchain_bom": {
+          "description": "Everything that produces the deployable artifact: engines/plans, compiled graphs, quantized models.",
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/build_toolchain_component" }
+        },
+        "runtime_execution_bom": {
+          "description": "Everything that loads and executes the artifact on the target SoC: firmware, drivers, OS, AI runtime/inference engine, harness/application layer.",
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/runtime_execution_component" }
+        }
+      }
+    },
+
+    "oss_components": {
+      "description": "Open-source projects used in toolchain or runtime, with immutable identifiers and patch disclosure.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/oss_component" }
+    },
+
+    "proprietary_components": {
+      "description": "Vendor/supplier-developed components in toolchain (e.g. compiler backend) and runtime (e.g. safety runtime, drivers) that affect the compiled artifact or its execution.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/proprietary_component" }
+    },
+
+    "license_summary": {
+      "description": "License family and redistribution terms per component across toolchain and runtime.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/license_entry" }
+    },
+
+    "reproducibility": {
+      "description": "Public-repo references and a reproducible model-compilation recipe so that, given the same environment and toolchain, results can be reproduced.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mlperf_automotive_repo_reference", "model_compilation_recipe"],
+      "properties": {
+        "mlperf_automotive_repo_reference": {
+          "$ref": "#/$defs/repo_reference"
+        },
+        "model_compilation_recipe": {
+          "description": "Per-model reproducible compilation recipes. The compiled model itself is NOT shipped; the recipe + toolchain access is what an auditor uses to reproduce it.",
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/compilation_recipe" }
+        }
+      }
+    },
+
+    "safety_evidence": {
+      "description": "Safety/security evidence appropriate to the profile. Required content is enforced by the checker per hardened_profile rather than by the schema, because IVI/ADAS/AD differ.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "security_manual_reference": { "$ref": "#/$defs/document_reference" },
+        "safety_manual_reference": { "$ref": "#/$defs/document_reference" },
+        "tool_qualification_reference": { "$ref": "#/$defs/document_reference" },
+        "hardware_qualification": {
+          "description": "HW qualification evidence, e.g. AEC-Q100, high-safety-integrity compute.",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "certification_evidence": {
+          "description": "Any evidence of an attempt at or progress toward certification. Free-form; an empty array means none claimed.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["standard", "status"],
+            "properties": {
+              "standard": {
+                "description": "e.g. ISO 26262, ISO 21448 (SOTIF), ISO 21434, IEC 61508.",
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "enum": ["none", "planned", "in_progress", "assessment", "certified"]
+              },
+              "asil_target": {
+                "type": "string",
+                "enum": ["QM", "ASIL-A", "ASIL-B", "ASIL-C", "ASIL-D", "not_applicable"]
+              },
+              "assessor": { "type": "string" },
+              "reference": { "$ref": "#/$defs/document_reference" }
+            }
+          }
+        }
+      }
+    }
+  },
+
+  "$defs": {
+    "audit_identifier": {
+      "description": "An immutable, uniquely-identifying handle for a component build, consistent with MLCommons replication rules. At least one of these forms must be present so a neutral auditor can pin the exact artifact even when source is not shared.",
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "repository_url": { "type": "string", "format": "uri" },
+        "commit_hash": { "type": "string", "pattern": "^[0-9a-fA-F]{7,64}$" },
+        "release_tag": { "type": "string" },
+        "build_id": { "type": "string" },
+        "binary_checksum": {
+          "description": "Algorithm-prefixed digest, e.g. 'sha256:ab12...'.",
+          "type": "string",
+          "pattern": "^(sha256|sha512|sha1|md5):[0-9a-fA-F]{32,128}$"
+        },
+        "internal_source_identifier": {
+          "description": "Opaque internal handle resolvable by the submitter for an auditor under NDA.",
+          "type": "string"
+        }
+      }
+    },
+
+    "inventory_component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "component_name",
+        "functional_role",
+        "supplier_or_owner",
+        "used_during_benchmark",
+        "intended_for_production",
+        "provenance",
+        "identifier"
+      ],
+      "properties": {
+        "component_name": { "type": "string", "minLength": 1 },
+        "functional_role": { "type": "string", "minLength": 1 },
+        "supplier_or_owner": { "type": "string", "minLength": 1 },
+        "used_during_benchmark": { "type": "boolean" },
+        "intended_for_production": { "type": "boolean" },
+        "provenance": {
+          "type": "string",
+          "enum": ["open-source", "proprietary", "mixed"]
+        },
+        "identifier": { "$ref": "#/$defs/audit_identifier" }
+      }
+    },
+
+    "build_toolchain_component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["component_name", "role", "version"],
+      "properties": {
+        "component_name": { "type": "string", "minLength": 1 },
+        "role": {
+          "description": "Functional class within the toolchain.",
+          "type": "string",
+          "enum": [
+            "training_framework",
+            "export_tooling",
+            "ml_compiler",
+            "optimizer",
+            "quantizer",
+            "calibration_tool",
+            "packaging_tool",
+            "container_builder",
+            "other"
+          ]
+        },
+        "version": { "type": "string", "minLength": 1 },
+        "configuration_flags": {
+          "description": "Flags/settings that materially affect the produced artifact. Recorded so the build is reproducible.",
+          "type": "string"
+        },
+        "calibration_dataset_description": {
+          "description": "Required-by-checker for quantizer/calibration roles: which calibration data and how much was used.",
+          "type": "string"
+        },
+        "identifier": { "$ref": "#/$defs/audit_identifier" }
+      }
+    },
+
+    "runtime_execution_component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["component_name", "component_type", "version"],
+      "properties": {
+        "component_name": { "type": "string", "minLength": 1 },
+        "component_type": {
+          "type": "string",
+          "enum": [
+            "firmware",
+            "kernel_driver",
+            "userspace_driver",
+            "operating_system",
+            "ai_runtime",
+            "inference_engine",
+            "safety_runtime",
+            "application",
+            "benchmark_harness",
+            "other"
+          ]
+        },
+        "version": { "type": "string", "minLength": 1 },
+        "configuration": {
+          "description": "Runtime config: device selection, scheduling mode, batching, hardening profile, delivery method, etc.",
+          "type": "string"
+        },
+        "delivery_method": {
+          "description": "For firmware: how it is delivered (BSP image, separate update).",
+          "type": "string"
+        },
+        "run_command": {
+          "description": "Required-by-checker for application/benchmark_harness components: run command/flags and how the app connects to the runtime and to LoadGen.",
+          "type": "string"
+        },
+        "identifier": { "$ref": "#/$defs/audit_identifier" }
+      }
+    },
+
+    "oss_component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["component_name", "upstream_url", "immutable_identifier", "role"],
+      "properties": {
+        "component_name": { "type": "string", "minLength": 1 },
+        "upstream_url": { "type": "string", "format": "uri" },
+        "immutable_identifier": {
+          "description": "Release tag or commit hash pinning the exact upstream revision.",
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "description": "Short description of its role in toolchain or runtime.",
+          "type": "string",
+          "minLength": 1
+        },
+        "has_local_patches": { "type": "boolean", "default": false },
+        "patch_reference": {
+          "description": "Patch/fork reference when patches can be shared.",
+          "type": "string"
+        },
+        "patch_feature_description": {
+          "description": "When patches cannot be shared: feature-level description of what changed, plus component boundary, inputs/outputs.",
+          "type": "string"
+        },
+        "affects_kernel_or_tactic_selection": {
+          "description": "Whether the patch/fork influences kernel or tactic selection (material to reproducibility/audit).",
+          "type": "boolean"
+        }
+      }
+    },
+
+    "proprietary_component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "component_name",
+        "owner",
+        "version_or_build_id",
+        "interface_role",
+        "internal_identifier_or_checksum",
+        "available_to_external_customers",
+        "distribution_model"
+      ],
+      "properties": {
+        "component_name": { "type": "string", "minLength": 1 },
+        "owner": { "type": "string", "minLength": 1 },
+        "version_or_build_id": { "type": "string", "minLength": 1 },
+        "interface_role": {
+          "description": "What it plugs into (e.g. 'compiler backend', 'safety runtime', 'kernel driver').",
+          "type": "string",
+          "minLength": 1
+        },
+        "internal_identifier_or_checksum": {
+          "description": "Uniquely identifies the exact build for audit.",
+          "type": "string",
+          "minLength": 1
+        },
+        "available_to_external_customers": { "type": "boolean" },
+        "distribution_model": {
+          "description": "e.g. 'production license', 'evaluation only', 'internal only'.",
+          "type": "string",
+          "minLength": 1
+        },
+        "affects_compiled_artifact": {
+          "description": "Whether this component affects the compiled artifact or its execution.",
+          "type": "boolean"
+        }
+      }
+    },
+
+    "license_entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "component_name",
+        "license_family",
+        "binary_redistribution_allowed",
+        "source_redistribution_allowed"
+      ],
+      "properties": {
+        "component_name": { "type": "string", "minLength": 1 },
+        "license_family": {
+          "description": "e.g. 'Apache-2.0', 'GPL-3.0', 'proprietary-commercial'.",
+          "type": "string",
+          "minLength": 1
+        },
+        "binary_redistribution_allowed": { "type": "boolean" },
+        "source_redistribution_allowed": { "type": "boolean" },
+        "additional_terms": {
+          "description": "e.g. 'NDA', 'safety manual required', 'field-of-use restriction', or null.",
+          "type": ["string", "null"]
+        }
+      }
+    },
+
+    "repo_reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["implementation_repo_url", "results_repo_url", "commit_hash"],
+      "properties": {
+        "implementation_repo_url": { "type": "string", "format": "uri" },
+        "results_repo_url": { "type": "string", "format": "uri" },
+        "commit_hash": { "type": "string", "pattern": "^[0-9a-fA-F]{7,64}$" }
+      }
+    },
+
+    "compilation_recipe": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["model", "steps", "compiler_config"],
+      "properties": {
+        "model": {
+          "description": "Benchmark model this recipe compiles. Must be one of the benchmark models for the package version.",
+          "type": "string",
+          "minLength": 1
+        },
+        "steps": {
+          "description": "Ordered reproducible steps: each is either an inline command string or a URI to a script.",
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "compiler_config": {
+          "description": "Compiler flags and settings.",
+          "type": "string",
+          "minLength": 1
+        },
+        "quantization_description": {
+          "description": "Principled description of the quantization method (per inference_rules: must be reproducible and much smaller than the weights it produces).",
+          "type": "string"
+        },
+        "graph_optimizations": {
+          "description": "Graph-level optimizations applied (fusion, layout, etc.).",
+          "type": "string"
+        },
+        "autotuning_config": {
+          "description": "REQUIRED-by-checker for target-dependent autotuning flows (e.g. TensorRT-style builders): the autotuning configuration needed to reproduce the build.",
+          "type": "string"
+        },
+        "target_dependent_autotuning": {
+          "description": "Whether compilation uses target-dependent autotuning. When true, autotuning_config is required.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+
+    "document_reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "availability": {
+          "description": "How an auditor obtains it, e.g. 'under NDA', 'public', 'on request'.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/tools/submission/hardened/test_hardened_checker.py
+++ b/tools/submission/hardened/test_hardened_checker.py
@@ -1,0 +1,164 @@
+"""Tests for hardened_checker.
+
+Run: python3 -m unittest mlperf_hardened.test_hardened_checker  (from repo root)
+ or: python3 test_hardened_checker.py                          (from this dir)
+
+Covers: the three valid example packages, every cross-field rule the schema can't
+express, and (optionally) JSON-Schema conformance if jsonschema happens to be installed.
+"""
+
+import copy
+import json
+import os
+import unittest
+
+import hardened_checker as hc
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+EX = os.path.join(HERE, "examples")
+SCHEMA = os.path.join(HERE, "schema", "hardened_package.schema.json")
+
+
+def load(name):
+    with open(os.path.join(EX, name)) as f:
+        return json.load(f)
+
+
+class ValidExamples(unittest.TestCase):
+    def test_adas_example_valid(self):
+        ok, errors, _ = hc.validate_hardened_package(load("drive_orin_adas_hardened.json"),
+                                                      "drive_orin_adas")
+        self.assertTrue(ok, "unexpected errors: %s" % errors)
+
+    def test_ivi_example_valid(self):
+        ok, errors, _ = hc.validate_hardened_package(load("ivi_qm_hardened.json"),
+                                                      "ivi_cockpit_qm")
+        self.assertTrue(ok, "unexpected errors: %s" % errors)
+
+    def test_invalid_example_fails(self):
+        ok, errors, _ = hc.validate_hardened_package(load("invalid_adas_hardened.json"),
+                                                      "broken_adas")
+        self.assertFalse(ok)
+        # spot-check that the headline rules each fired
+        blob = " | ".join(errors)
+        self.assertIn("safety_manual_reference", blob)
+        self.assertIn("tool_qualification_reference", blob)
+        self.assertIn("calibration_dataset_description", blob)
+        self.assertIn("run_command", blob)
+        self.assertIn("autotuning_config", blob)
+        self.assertIn("commit_hash", blob)
+        self.assertIn("patch", blob)
+
+
+class CrossFieldRules(unittest.TestCase):
+    def setUp(self):
+        self.pkg = load("drive_orin_adas_hardened.json")
+
+    def _expect_error_containing(self, pkg, needle):
+        ok, errors, _ = hc.validate_hardened_package(pkg, pkg.get("system_desc_id"))
+        self.assertFalse(ok)
+        self.assertTrue(any(needle in e for e in errors),
+                        "expected an error containing %r, got %s" % (needle, errors))
+
+    def test_profile_must_be_known(self):
+        self.pkg["hardened_profile"] = "L5"
+        self._expect_error_containing(self.pkg, "hardened_profile")
+
+    def test_system_desc_id_must_match(self):
+        ok, errors, _ = hc.validate_hardened_package(self.pkg, "different_id")
+        self.assertFalse(ok)
+        self.assertTrue(any("does not match" in e for e in errors), errors)
+
+    def test_adas_requires_safety_manual(self):
+        del self.pkg["safety_evidence"]["safety_manual_reference"]
+        self._expect_error_containing(self.pkg, "safety_manual_reference")
+
+    def test_ivi_does_not_require_safety_manual(self):
+        ivi = load("ivi_qm_hardened.json")
+        self.assertNotIn("safety_manual_reference", ivi.get("safety_evidence", {}))
+        ok, errors, _ = hc.validate_hardened_package(ivi, "ivi_cockpit_qm")
+        self.assertTrue(ok, errors)
+
+    def test_quantizer_requires_calibration(self):
+        for c in self.pkg["software_bill_of_materials"]["build_toolchain_bom"]:
+            if c["role"] == "quantizer":
+                c.pop("calibration_dataset_description", None)
+        self._expect_error_containing(self.pkg, "calibration_dataset_description")
+
+    def test_application_requires_run_command(self):
+        for c in self.pkg["software_bill_of_materials"]["runtime_execution_bom"]:
+            if c["component_type"] == "application":
+                c.pop("run_command", None)
+        self._expect_error_containing(self.pkg, "run_command")
+
+    def test_autotuning_requires_config(self):
+        self.pkg["reproducibility"]["model_compilation_recipe"][0].pop("autotuning_config")
+        self._expect_error_containing(self.pkg, "autotuning_config")
+
+    def test_no_autotuning_no_config_is_fine(self):
+        r = self.pkg["reproducibility"]["model_compilation_recipe"][0]
+        r["target_dependent_autotuning"] = False
+        r.pop("autotuning_config", None)
+        ok, errors, _ = hc.validate_hardened_package(self.pkg, "drive_orin_adas")
+        self.assertTrue(ok, errors)
+
+    def test_audit_identifier_must_pin_something(self):
+        self.pkg["production_intended_inventory"][0]["identifier"] = {}
+        self._expect_error_containing(self.pkg, "identifier")
+
+    def test_bad_checksum_format_rejected(self):
+        self.pkg["production_intended_inventory"][0]["identifier"] = {
+            "binary_checksum": "deadbeef"}
+        self._expect_error_containing(self.pkg, "binary_checksum")
+
+    def test_patch_without_disclosure_rejected(self):
+        for c in self.pkg["oss_components"]:
+            if c["component_name"] == "ONNX Runtime":
+                c.pop("patch_feature_description", None)
+                c.pop("patch_reference", None)
+        self._expect_error_containing(self.pkg, "patch")
+
+    def test_unknown_model_is_warning_not_error(self):
+        self.pkg["reproducibility"]["model_compilation_recipe"][0]["model"] = "mystery_net"
+        ok, errors, warnings = hc.validate_hardened_package(self.pkg, "drive_orin_adas")
+        self.assertTrue(ok, errors)
+        self.assertTrue(any("mystery_net" in w for w in warnings), warnings)
+
+    def test_missing_required_top_section(self):
+        del self.pkg["software_bill_of_materials"]
+        self._expect_error_containing(self.pkg, "software_bill_of_materials")
+
+    def test_benchmark_only_inventory_warns(self):
+        for c in self.pkg["production_intended_inventory"]:
+            c["intended_for_production"] = False
+        ok, errors, warnings = hc.validate_hardened_package(self.pkg, "drive_orin_adas")
+        self.assertTrue(ok, errors)
+        self.assertTrue(any("intended_for_production" in w for w in warnings), warnings)
+
+
+class SchemaConformance(unittest.TestCase):
+    """Only runs if jsonschema is installed; the production checker does not need it."""
+
+    def setUp(self):
+        try:
+            import jsonschema  # noqa: F401
+        except ImportError:
+            self.skipTest("jsonschema not installed (optional)")
+        with open(SCHEMA) as f:
+            self.schema = json.load(f)
+
+    def test_valid_examples_match_schema(self):
+        import jsonschema
+        for name in ("drive_orin_adas_hardened.json", "ivi_qm_hardened.json"):
+            jsonschema.validate(load(name), self.schema)
+
+    def test_invalid_example_violates_schema_or_checker(self):
+        # The invalid example is crafted to fail the *checker*; it may still be
+        # structurally schema-valid (the cross-field rules are checker-only). This
+        # test just asserts the schema itself is a valid draft-07 document.
+        import jsonschema
+        jsonschema.Draft7Validator.check_schema(self.schema)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/submission/hardened_checker.py
+++ b/tools/submission/hardened_checker.py
@@ -1,0 +1,446 @@
+"""Validator for the MLPerf Automotive 'Hardened System' submission package.
+
+This module checks the *additional* disclosure package required by the Hardened
+submission category (inference_rules.adoc 6.1) on top of the ordinary MLCommons
+submission artifacts that ``submission_checker.py`` already validates.
+
+Design goals (kept deliberately aligned with the existing tools/submission code):
+  * Pure standard library -- no ``jsonschema`` runtime dependency, exactly like
+    ``submission_checker.py``. The JSON Schema in schema/hardened_package.schema.json
+    is the normative spec; this file is the executable enforcement that also covers
+    the cross-field rules draft-07 cannot express.
+  * Same reporting idiom: ``log.error`` for things that invalidate a submission and
+    ``log.warning`` for things a reviewer should look at. The boolean return mirrors
+    ``check_system_desc_id`` so it drops straight into ``check_results_dir``.
+  * Keyed by package version (``v0.5`` / ``v1.0``) the same way MODEL_CONFIG keys the
+    base checker, so the set of benchmark models is taken from the base config rather
+    than duplicated here.
+
+Integration: call ``check_hardened_package`` right after the base checker confirms
+``status == "hardened"`` (submission_checker.py ~line 1808). See INTEGRATION.md.
+"""
+
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import json
+import logging
+import os
+import re
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("hardened")
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Profiles defined by inference_rules.adoc 6.1. The required evidence differs per
+# profile; this table is the machine-readable form of that section's table.
+#   security_manual  -> always required
+#   safety_manual    -> required for ADAS/AD (the '*' / "depending on safety concept")
+#   tool_qualification -> required for ADAS/AD
+HARDENED_PROFILES = {
+    "IVI": {
+        "requires_security_manual": True,
+        "requires_safety_manual": False,
+        "requires_tool_qualification": False,
+        "typical_safety_goal": "QM",
+    },
+    "ADAS": {
+        "requires_security_manual": True,
+        "requires_safety_manual": True,
+        "requires_tool_qualification": True,
+        "typical_safety_goal": "QM..ASIL-B",
+    },
+    "AD": {
+        "requires_security_manual": True,
+        "requires_safety_manual": True,
+        "requires_tool_qualification": True,
+        "typical_safety_goal": "ASIL-B and above",
+    },
+}
+
+VALID_PACKAGE_VERSIONS = ["v0.5", "v1.0"]
+
+VALID_PROVENANCE = ["open-source", "proprietary", "mixed"]
+
+VALID_BUILD_ROLES = [
+    "training_framework", "export_tooling", "ml_compiler", "optimizer",
+    "quantizer", "calibration_tool", "packaging_tool", "container_builder", "other",
+]
+# Build roles whose output depends on a calibration set must describe it.
+BUILD_ROLES_NEEDING_CALIBRATION = ["quantizer", "calibration_tool"]
+
+VALID_RUNTIME_TYPES = [
+    "firmware", "kernel_driver", "userspace_driver", "operating_system",
+    "ai_runtime", "inference_engine", "safety_runtime", "application",
+    "benchmark_harness", "other",
+]
+# Runtime components that actually drive the run must disclose the run command.
+RUNTIME_TYPES_NEEDING_RUN_COMMAND = ["application", "benchmark_harness"]
+
+# An audit identifier must carry at least one of these uniquely-pinning forms.
+AUDIT_ID_FORMS = [
+    "repository_url", "commit_hash", "release_tag", "build_id",
+    "binary_checksum", "internal_source_identifier",
+]
+
+_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
+_CHECKSUM_RE = re.compile(r"^(sha256|sha512|sha1|md5):[0-9a-fA-F]{32,128}$")
+
+
+# ---------------------------------------------------------------------------
+# Small helpers (kept local so the module is import-free beyond stdlib)
+# ---------------------------------------------------------------------------
+
+def _require(obj, field, ctx, errors):
+    """Field must be present and non-empty (matching the base checker's notion of
+    a 'meaningful response')."""
+    if field not in obj or obj[field] in (None, "", [], {}):
+        errors.append("%s: field '%s' is missing or empty" % (ctx, field))
+        return False
+    return True
+
+
+def _check_audit_identifier(ident, ctx, errors):
+    if not isinstance(ident, dict) or not ident:
+        errors.append("%s: identifier must be a non-empty object with at least one "
+                      "of %s" % (ctx, AUDIT_ID_FORMS))
+        return
+    if not any(ident.get(f) for f in AUDIT_ID_FORMS):
+        errors.append("%s: identifier carries none of %s -- an auditor cannot pin the "
+                      "exact build" % (ctx, AUDIT_ID_FORMS))
+    commit = ident.get("commit_hash")
+    if commit and not _COMMIT_RE.match(commit):
+        errors.append("%s: commit_hash '%s' is not a valid hex hash" % (ctx, commit))
+    checksum = ident.get("binary_checksum")
+    if checksum and not _CHECKSUM_RE.match(checksum):
+        errors.append("%s: binary_checksum '%s' must look like 'sha256:<hex>'"
+                      % (ctx, checksum))
+
+
+# ---------------------------------------------------------------------------
+# Section checks
+# ---------------------------------------------------------------------------
+
+def _check_inventory(pkg, errors, warnings):
+    items = pkg.get("production_intended_inventory")
+    if not isinstance(items, list) or not items:
+        errors.append("production_intended_inventory: must be a non-empty array")
+        return
+    saw_production = False
+    for i, c in enumerate(items):
+        ctx = "production_intended_inventory[%d]" % i
+        for f in ("component_name", "functional_role", "supplier_or_owner"):
+            _require(c, f, ctx, errors)
+        for f in ("used_during_benchmark", "intended_for_production"):
+            if not isinstance(c.get(f), bool):
+                errors.append("%s: field '%s' must be a boolean" % (ctx, f))
+        prov = c.get("provenance")
+        if prov not in VALID_PROVENANCE:
+            errors.append("%s: provenance '%s' not in %s" % (ctx, prov, VALID_PROVENANCE))
+        if "identifier" in c:
+            _check_audit_identifier(c["identifier"], ctx, errors)
+        else:
+            errors.append("%s: field 'identifier' is missing" % ctx)
+        if c.get("intended_for_production"):
+            saw_production = True
+    if not saw_production:
+        warnings.append("production_intended_inventory: no component is marked "
+                        "intended_for_production -- a hardened submission is expected "
+                        "to declare a production path")
+
+
+def _check_bom(pkg, errors, warnings):
+    bom = pkg.get("software_bill_of_materials")
+    if not isinstance(bom, dict):
+        errors.append("software_bill_of_materials: must be an object with "
+                      "build_toolchain_bom and runtime_execution_bom")
+        return
+
+    build = bom.get("build_toolchain_bom")
+    if not isinstance(build, list) or not build:
+        errors.append("software_bill_of_materials.build_toolchain_bom: non-empty array required")
+    else:
+        for i, c in enumerate(build):
+            ctx = "build_toolchain_bom[%d]" % i
+            _require(c, "component_name", ctx, errors)
+            _require(c, "version", ctx, errors)
+            role = c.get("role")
+            if role not in VALID_BUILD_ROLES:
+                errors.append("%s: role '%s' not in %s" % (ctx, role, VALID_BUILD_ROLES))
+            if role in BUILD_ROLES_NEEDING_CALIBRATION and not c.get(
+                    "calibration_dataset_description"):
+                errors.append("%s: role '%s' requires calibration_dataset_description"
+                              % (ctx, role))
+            if "identifier" in c:
+                _check_audit_identifier(c["identifier"], ctx, errors)
+
+    runtime = bom.get("runtime_execution_bom")
+    if not isinstance(runtime, list) or not runtime:
+        errors.append("software_bill_of_materials.runtime_execution_bom: non-empty array required")
+        return
+
+    seen_types = set()
+    for i, c in enumerate(runtime):
+        ctx = "runtime_execution_bom[%d]" % i
+        _require(c, "component_name", ctx, errors)
+        _require(c, "version", ctx, errors)
+        ctype = c.get("component_type")
+        if ctype not in VALID_RUNTIME_TYPES:
+            errors.append("%s: component_type '%s' not in %s"
+                          % (ctx, ctype, VALID_RUNTIME_TYPES))
+        else:
+            seen_types.add(ctype)
+        if ctype in RUNTIME_TYPES_NEEDING_RUN_COMMAND and not c.get("run_command"):
+            errors.append("%s: component_type '%s' requires run_command (how the app "
+                          "connects to the runtime and to LoadGen)" % (ctx, ctype))
+        if "identifier" in c:
+            _check_audit_identifier(c["identifier"], ctx, errors)
+
+    # The runtime stack of a production-intended ECU is expected to disclose, at
+    # minimum, firmware/OS and the engine that executes the artifact.
+    for expected in ("firmware", "operating_system"):
+        if expected not in seen_types:
+            warnings.append("runtime_execution_bom: no component of type '%s' disclosed"
+                            % expected)
+    if not ({"ai_runtime", "inference_engine", "safety_runtime"} & seen_types):
+        warnings.append("runtime_execution_bom: no ai_runtime/inference_engine/"
+                        "safety_runtime disclosed -- something must execute the artifact")
+
+
+def _check_oss(pkg, errors, warnings):
+    items = pkg.get("oss_components", [])
+    if not isinstance(items, list):
+        errors.append("oss_components: must be an array")
+        return
+    for i, c in enumerate(items):
+        ctx = "oss_components[%d]" % i
+        for f in ("component_name", "upstream_url", "immutable_identifier", "role"):
+            _require(c, f, ctx, errors)
+        # If a fork/patch exists it must be either referenced or described at feature
+        # level (the rules explicitly allow "describe instead of share").
+        if c.get("has_local_patches") and not (
+                c.get("patch_reference") or c.get("patch_feature_description")):
+            errors.append("%s: has_local_patches is true but neither patch_reference "
+                          "nor patch_feature_description is provided" % ctx)
+
+
+def _check_proprietary(pkg, errors, warnings):
+    items = pkg.get("proprietary_components", [])
+    if not isinstance(items, list):
+        errors.append("proprietary_components: must be an array")
+        return
+    for i, c in enumerate(items):
+        ctx = "proprietary_components[%d]" % i
+        for f in ("component_name", "owner", "version_or_build_id", "interface_role",
+                  "internal_identifier_or_checksum", "distribution_model"):
+            _require(c, f, ctx, errors)
+        if not isinstance(c.get("available_to_external_customers"), bool):
+            errors.append("%s: available_to_external_customers must be a boolean" % ctx)
+
+
+def _check_licensing(pkg, errors, warnings):
+    items = pkg.get("license_summary", [])
+    if not isinstance(items, list):
+        errors.append("license_summary: must be an array")
+        return
+    for i, c in enumerate(items):
+        ctx = "license_summary[%d]" % i
+        _require(c, "component_name", ctx, errors)
+        _require(c, "license_family", ctx, errors)
+        for f in ("binary_redistribution_allowed", "source_redistribution_allowed"):
+            if not isinstance(c.get(f), bool):
+                errors.append("%s: field '%s' must be a boolean" % (ctx, f))
+
+
+def _check_reproducibility(pkg, version, errors, warnings):
+    repro = pkg.get("reproducibility")
+    if not isinstance(repro, dict):
+        errors.append("reproducibility: object required")
+        return
+
+    ref = repro.get("mlperf_automotive_repo_reference")
+    if not isinstance(ref, dict):
+        errors.append("reproducibility.mlperf_automotive_repo_reference: object required")
+    else:
+        for f in ("implementation_repo_url", "results_repo_url", "commit_hash"):
+            _require(ref, f, "mlperf_automotive_repo_reference", errors)
+        commit = ref.get("commit_hash")
+        if commit and not _COMMIT_RE.match(commit):
+            errors.append("mlperf_automotive_repo_reference: commit_hash '%s' is not a "
+                          "valid hex hash" % commit)
+
+    recipes = repro.get("model_compilation_recipe")
+    if not isinstance(recipes, list) or not recipes:
+        errors.append("reproducibility.model_compilation_recipe: non-empty array required")
+        return
+
+    valid_models = _models_for_version(version)
+    for i, r in enumerate(recipes):
+        ctx = "model_compilation_recipe[%d]" % i
+        model = r.get("model")
+        if not model:
+            errors.append("%s: field 'model' is missing" % ctx)
+        elif valid_models is not None and model not in valid_models:
+            # Closed/network only; open submissions may use custom names so this is a
+            # warning to leave room for open-division recipes.
+            warnings.append("%s: model '%s' is not a known benchmark model %s"
+                            % (ctx, model, sorted(valid_models)))
+        if not (isinstance(r.get("steps"), list) and r["steps"]):
+            errors.append("%s: 'steps' must be a non-empty array" % ctx)
+        _require(r, "compiler_config", ctx, errors)
+        # Target-dependent autotuning (TensorRT-style builders) must ship the
+        # autotuning config or the build is not reproducible.
+        if r.get("target_dependent_autotuning") and not r.get("autotuning_config"):
+            errors.append("%s: target_dependent_autotuning is true but autotuning_config "
+                          "is missing -- required for TensorRT-style builders" % ctx)
+
+
+def _check_safety_evidence(pkg, profile, errors, warnings):
+    rules = HARDENED_PROFILES[profile]
+    ev = pkg.get("safety_evidence", {})
+    if not isinstance(ev, dict):
+        errors.append("safety_evidence: object required")
+        ev = {}
+
+    def _doc_present(key):
+        d = ev.get(key)
+        return isinstance(d, dict) and d.get("name") and d.get("version")
+
+    if rules["requires_security_manual"] and not _doc_present("security_manual_reference"):
+        errors.append("safety_evidence: profile '%s' requires a security_manual_reference "
+                      "(name + version)" % profile)
+    if rules["requires_safety_manual"] and not _doc_present("safety_manual_reference"):
+        errors.append("safety_evidence: profile '%s' requires a safety_manual_reference "
+                      "(name + version)" % profile)
+    if rules["requires_tool_qualification"] and not _doc_present("tool_qualification_reference"):
+        errors.append("safety_evidence: profile '%s' requires a tool_qualification_reference "
+                      "(name + version)" % profile)
+
+    # MLPerf does not certify safety; certification evidence is optional but, when
+    # present, each entry must name a standard and a status.
+    for i, c in enumerate(ev.get("certification_evidence", []) or []):
+        ctx = "safety_evidence.certification_evidence[%d]" % i
+        _require(c, "standard", ctx, errors)
+        _require(c, "status", ctx, errors)
+
+    if not ev.get("hardware_qualification"):
+        warnings.append("safety_evidence: no hardware_qualification listed (e.g. AEC-Q100 "
+                        "is expected for all profiles)")
+
+
+# ---------------------------------------------------------------------------
+# Version -> models. Resolved from the base checker's MODEL_CONFIG when available
+# so we never duplicate the benchmark list; falls back to a static copy if the
+# base module cannot be imported (keeps this file independently testable).
+# ---------------------------------------------------------------------------
+
+_FALLBACK_MODELS = {
+    "v0.5": {"bevformer", "deeplabv3plus", "ssd"},
+    "v1.0": {"bevformer", "deeplabv3plus", "ssd", "llama3_1-8b", "uniad"},
+}
+
+
+def _models_for_version(version):
+    try:
+        import submission_checker  # noqa: WPS433 (optional, integration-time)
+        cfg = submission_checker.MODEL_CONFIG.get(version)
+        if cfg and "models" in cfg:
+            return set(cfg["models"])
+    except Exception:  # pragma: no cover - import path only available in-tree
+        pass
+    return _FALLBACK_MODELS.get(version)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def validate_hardened_package(pkg, system_desc_id=None):
+    """Validate a parsed hardened package dict.
+
+    Returns ``(is_valid, errors, warnings)``. ``is_valid`` is True iff there are no
+    errors. The caller decides how to surface warnings.
+    """
+    errors = []
+    warnings = []
+
+    if not isinstance(pkg, dict):
+        return False, ["hardened package: top-level value must be a JSON object"], []
+
+    version = pkg.get("hardened_package_version")
+    if version not in VALID_PACKAGE_VERSIONS:
+        errors.append("hardened_package_version '%s' not in %s"
+                      % (version, VALID_PACKAGE_VERSIONS))
+        # Without a version we cannot resolve model lists; keep going but model checks
+        # will use the fallback / be skipped.
+
+    declared_id = pkg.get("system_desc_id")
+    if not declared_id:
+        errors.append("system_desc_id: field is missing")
+    elif system_desc_id is not None and declared_id != system_desc_id:
+        errors.append("system_desc_id '%s' does not match the system description "
+                      "filename '%s'" % (declared_id, system_desc_id))
+
+    profile = pkg.get("hardened_profile")
+    if profile not in HARDENED_PROFILES:
+        errors.append("hardened_profile '%s' not in %s"
+                      % (profile, sorted(HARDENED_PROFILES)))
+
+    _check_inventory(pkg, errors, warnings)
+    _check_bom(pkg, errors, warnings)
+    _check_oss(pkg, errors, warnings)
+    _check_proprietary(pkg, errors, warnings)
+    _check_licensing(pkg, errors, warnings)
+    _check_reproducibility(pkg, version, errors, warnings)
+    if profile in HARDENED_PROFILES:
+        _check_safety_evidence(pkg, profile, errors, warnings)
+
+    return (len(errors) == 0), errors, warnings
+
+
+def check_hardened_package(name, hardened_json_path, system_desc_id=None):
+    """File-level wrapper that mirrors ``check_system_desc_id`` in submission_checker.py:
+    logs errors/warnings and returns a single boolean so it can be dropped into
+    ``check_results_dir`` right after the ``status == 'hardened'`` branch.
+
+    ``name`` is the human-readable results path used in the base checker's messages.
+    """
+    if not os.path.exists(hardened_json_path):
+        log.error("%s: hardened submission requires %s", name, hardened_json_path)
+        return False
+
+    try:
+        with open(hardened_json_path) as f:
+            pkg = json.load(f)
+    except (ValueError, OSError) as exc:
+        log.error("%s: cannot parse hardened package %s (%s)",
+                  name, hardened_json_path, exc)
+        return False
+
+    is_valid, errors, warnings = validate_hardened_package(pkg, system_desc_id)
+    for w in warnings:
+        log.warning("%s: %s", name, w)
+    for e in errors:
+        log.error("%s: %s", name, e)
+    return is_valid
+
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="Validate an MLPerf Automotive Hardened Category package.")
+    parser.add_argument("package", help="path to <system_desc>_hardened.json")
+    parser.add_argument("--system-desc-id",
+                        help="expected system_desc_id (basename of the systems json)")
+    args = parser.parse_args()
+
+    ok = check_hardened_package(args.package, args.package, args.system_desc_id)
+    if ok:
+        log.info("%s: hardened package is VALID", args.package)
+    sys.exit(0 if ok else 1)


### PR DESCRIPTION
Adds an additive, opt-in validator for the MLPerf Automotive Hardened category (status == "hardened"):
- tools/submission/hardened_checker.py (stdlib-only, mirrors submission_checker)
- normative JSON Schema, worked examples (ADAS/IVI/invalid), 19 unit tests
- INTEGRATION.md: ~10-line patch into submission_checker.py after the status check

No existing behaviour changes; the check fires only for hardened submissions.